### PR TITLE
Add histogram stat type, update spec

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -304,7 +304,7 @@ class Statsd
     when nil, false, '' then @tags = nil
     else @tags = ",#{tgs}"
     end
-  end  
+  end
 
   # @attribute [w] host
   #   Writes are not thread safe.
@@ -394,6 +394,18 @@ class Statsd
   # @param [Numeric] sample_rate sample rate, 1 for always
   def timing(stat, ms, sample_rate=1)
     send_stats stat, ms, :ms, sample_rate
+  end
+
+  # Sends a integer as a value for the given stat to the statsd server. The
+  # sample_rate determines what percentage of the time this report is sent. The
+  # statsd server then uses the sample_rate to correctly track the average
+  # timing for the stat.
+  #
+  # @param [String] stat stat name
+  # @param [Integer] value metric value, as integer
+  # @param [Numeric] sample_rate sample rate, 1 for always
+  def histogram(stat, value, sample_rate=1)
+    send_stats stat, value, :h, sample_rate
   end
 
   # Reports execution time of the provided block using {#timing}.

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -6,6 +6,7 @@ SimpleCov.start
 require 'minitest/autorun'
 require 'statsd'
 require 'logger'
+require 'timeout'
 
 class FakeUDPSocket
   def initialize

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -70,12 +70,12 @@ describe Statsd do
     end
   end
 
-  describe "#delimiter" do 
+  describe "#delimiter" do
     it "should set delimiter" do
       @statsd.delimiter = "-"
       @statsd.delimiter.must_equal "-"
     end
-    
+
     it "should set default to period if not given a value" do
       @statsd.delimiter = nil
       @statsd.delimiter.must_equal "."
@@ -140,6 +140,21 @@ describe Statsd do
       it "should format the message according to the statsd spec" do
         @statsd.timing('foobar', 500, 0.5)
         @socket.recv.must_equal ['foobar:500|ms|@0.5']
+      end
+    end
+  end
+
+  describe "#histogram" do
+    it "should format the message according to the statsd spec" do
+      @statsd.histogram('foobar', 500)
+      @socket.recv.must_equal ['foobar:500|h']
+    end
+
+    describe "with a sample rate" do
+      before { class << @statsd; def rand; 0; end; end } # ensure delivery
+      it "should format the message according to the statsd spec" do
+        @statsd.histogram('foobar', 500, 0.5)
+        @socket.recv.must_equal ['foobar:500|h|@0.5']
       end
     end
   end

--- a/statsd-ruby.gemspec
+++ b/statsd-ruby.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
 
-Gem::Specification.new("statsd-ruby", "1.3.0") do |s|
-  s.authors = ["Rein Henrichs"]
-  s.email = "reinh@reinh.com"
+Gem::Specification.new("statsd-ruby", "1.4.0") do |s|
+  s.authors = ["Logan Mcdonald", "Kyle Burckhard", "Rein Henrichs"]
+  s.email = "devops@kickstarter.com"
 
   s.summary = "A Ruby StatsD client"
   s.description = "A Ruby StatsD client (https://github.com/etsy/statsd)"
 
-  s.homepage = "https://github.com/reinh/statsd"
-  s.licenses = %w[MIT]
+  s.homepage = "https://github.com/kickstarter/statsd-1"
+  # s.licenses = %w[MIT]
 
   s.extra_rdoc_files = %w[LICENSE.txt README.rdoc]
 
@@ -22,4 +22,3 @@ Gem::Specification.new("statsd-ruby", "1.3.0") do |s|
   s.add_development_dependency "simplecov", ">= 0.6.4"
   s.add_development_dependency "rake"
 end
-


### PR DESCRIPTION
# What

Adds support for the histogram type of statsd, this was added late to the spec but is supported by Telegraf. In reality it's just a rename for the timing type but timings are supposed to be just for things in `ms` this is for an value where we want the count, average, pertentiles. 

# Why

Cause it's cooler to send useful values then just incrementing things. If we want the count we can just `sum(statsd_<name>_count)`. 

# Who
@kickstarter/devops